### PR TITLE
refactor: Refactor SpaceGenerator implementation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,21 +1,21 @@
 use pyo3::prelude::*;
 
+mod analyizer;
 mod embedding;
 mod fio;
 mod space;
 mod util;
 mod web;
-mod analyizer;
 
 use embedding::models::Token;
 
 use fio::reader::conceptx::ConceptXReader;
 use fio::reader::Reader;
 
-use crate::space::seeds::SubspaceSeeds;
 use crate::analyizer::calculator::Calculator;
-use crate::space::space_generator::Space;
 use crate::analyizer::SpaceCalculator;
+use crate::space::seeds::SubspaceSeeds;
+use crate::space::space_generator::Space;
 use space::SpaceGenerator;
 
 #[pyfunction]
@@ -40,9 +40,6 @@ fn calculator(
 ) -> Calculator {
     let data = ConceptXReader::new().read(path, user_friendly.unwrap_or(false));
 
-    // turn each item of subspace_seed into raw format
-    println!("Subspace seeds: {:?}", subspace_seeds);
-
     let mut num_of_tokens = 0;
     for line in &data {
         num_of_tokens += line.tokens.len();
@@ -64,15 +61,19 @@ fn calculator(
     let mut sub_spaces: Vec<Space> = Vec::new();
 
     for subspace_seed in subspace_seeds {
-        let sub_space = Space::new(space.find(&subspace_seed.seeds), Some(subspace_seed), None);
+        let sub_space = Space::new(space.find(&subspace_seed), Some(subspace_seed), None);
         sub_spaces.push(sub_space);
     }
 
     // compute the bias of the random subspace
-    Calculator::new(match model_name {
-        Some(name) => name,
-        None => path.to_string()
-    }, neutral_space, sub_spaces)
+    Calculator::new(
+        match model_name {
+            Some(name) => name,
+            None => path.to_string(),
+        },
+        neutral_space,
+        sub_spaces,
+    )
 }
 
 #[pyfunction]

--- a/src/space/mod.rs
+++ b/src/space/mod.rs
@@ -6,13 +6,9 @@ use crate::embedding::models::TokenOperators;
 use seeds::SubspaceSeeds;
 
 pub trait SpaceGenerator {
-    fn new<T: TokenOperators>(
-        items: T,
-        words_of_interests: Option<SubspaceSeeds>,
-        pca_dimension: Option<usize>,
-    ) -> Self;
+    fn new<T: TokenOperators>(items: T, words_of_interests: Option<SubspaceSeeds>, pca_dimension: Option<usize>) -> Self;
     fn set_space_name(&mut self, name: String);
-    fn find(&self, words_of_interests: &Vec<String>) -> Vec<Token>;
+    fn find(&self, subspace_seed: &SubspaceSeeds) -> Vec<Token>;
     fn get_center(&self) -> Vec<f64>;
     fn get_std(&self) -> Vec<f64>;
     fn get_neutral_tokens(&self, exclude: Vec<String>) -> Vec<Token>;


### PR DESCRIPTION
- Rename 'words_of_interests' to 'subspace_seed_words' for clarity.
- Adjust the SpaceGenerator logic to handle SubspaceSeeds correctly.
- Update the find method to accept SubspaceSeeds as input.
- Simplify the PCA logic and remove unnecessary print statements.